### PR TITLE
Adds missing django_nose dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django
+django_nose
 unicodecsv
 jsonfield


### PR DESCRIPTION
Running python manage.py syncdb returns

```
ImportError: No module named django_nose
```

because turkle/settings.py includes django_nose in INSTALLED_APPS
