### PR TITLE
 Option to generate random next hit on submit

### DIFF
--- a/hits/views.py
+++ b/hits/views.py
@@ -1,3 +1,5 @@
+import random
+
 from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.template import loader
@@ -43,9 +45,13 @@ def submission(request, hit_id):
     h.save()
 
     if hasattr(settings, 'NEXT_HIT_ON_SUBMIT') and settings.NEXT_HIT_ON_SUBMIT:
+        next_hit_random = hasattr(settings, 'RANDOM_NEXT_HIT_ON_SUBMIT') and \
+                          settings.RANDOM_NEXT_HIT_ON_SUBMIT
         unfinished_hits = Hit.objects.filter(completed=False).order_by('id')
         try:
-            return redirect(detail, unfinished_hits[0].id)
+            next_hit = random.choice(unfinished_hits) if next_hit_random \
+                else unfinished_hits[0]
+            return redirect(detail, next_hit.id)
         except IndexError:
             pass
 

--- a/turkle/settings.py
+++ b/turkle/settings.py
@@ -164,6 +164,7 @@ LOGGING = {
 }
 
 NEXT_HIT_ON_SUBMIT = False
+RANDOM_NEXT_HIT_ON_SUBMIT = False  # Only valid when NEXT_HIT_ON_SUBMIT is True
 
 # Set max size for file uploads and POST requests to 100MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 104857600

--- a/turkle/settings.py
+++ b/turkle/settings.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 import os
 # Django settings for turkle project.
 
-DEBUG = True
+DEBUG = False
+ALLOWED_HOSTS = ['*']
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),


### PR DESCRIPTION
RANDOM_NEXT_HIT_ON_SUBMIT option helps mitigate overlap between many people doing hits at the same time.

Additional technical changes:
- DEBUG option disabled by default.
- utf-8 coding for the file solving issues like admins with diacritic chars in the name.
- ALLOWED_HOSTS set to accept '*' without this I could not start the app.