### PR TITLE
Limit CSV field size limit for Windows compatibility.

### DIFF
--- a/turkle/models.py
+++ b/turkle/models.py
@@ -5,6 +5,7 @@ import os.path
 import re
 import statistics
 import sys
+import ctypes
 
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
@@ -19,8 +20,13 @@ from .utils import get_turkle_template_limit
 
 logger = logging.getLogger(__name__)
 
-# The default field size limit is 131072 characters
-csv.field_size_limit(sys.maxsize)
+C_LONG_NUM_BITS = 8 * ctypes.sizeof(ctypes.c_long)
+C_LONG_MAX = 2 ** (C_LONG_NUM_BITS-1) - 1
+
+# Increase default field size limit (default 131072 characters).
+# Note that field_size_limit converts its argument to a C long,
+# at least in Anaconda 3 on Windows 10.
+csv.field_size_limit(min(C_LONG_MAX, sys.maxsize))
 
 
 class Task(models.Model):


### PR DESCRIPTION
Limit CSV field size limit to max size of C long (computed using ctypes and assuming two's complement) to prevent OverflowError when running `python manage.py migrate` on my setup.

Note: the C long constraint reported in the OverflowError [does not appear in the API docs](https://docs.python.org/3.5/library/csv.html#csv.field_size_limit).  However, I think we can safely expect the C long to be at least four bytes, so the field size limit under this change will be at least 2 GB.  I hope, for the sake of the workers' browsers, nobody's going over that. 😄 

Fixes #43.