### PR TITLE
fixes display of time left on assignment

### DIFF
--- a/turkle/templates/task_assignment.html
+++ b/turkle/templates/task_assignment.html
@@ -29,8 +29,8 @@ $(function () {
   $("#expiration-timer").countdown(expirationTime)
                         .on('update.countdown', function(event) {
                           var format = '%I:%M';
-                          // if greater than 1 full day left, display as days rather than hours:mins
-                          if (event.offset.totalDays > 1) {
+                          // if 3 full days left or more, display as days rather than hours:mins
+                          if (event.offset.totalDays > 2) {
                             format = "%-d day%!d";
                           }
                           $(this).text(event.strftime('Expires in ' + format));

--- a/turkle/templates/task_assignment.html
+++ b/turkle/templates/task_assignment.html
@@ -28,7 +28,12 @@ $(function () {
   var expirationTime = new Date('{{ task_assignment.expires_at|date:'c' }}');
   $("#expiration-timer").countdown(expirationTime)
                         .on('update.countdown', function(event) {
-                          $(this).text(event.strftime('Expires in %H:%M'))
+                          var format = '%I:%M';
+                          // if greater than 1 full day left, display as days rather than hours:mins
+                          if (event.offset.totalDays > 1) {
+                            format = "%-d day%!d";
+                          }
+                          $(this).text(event.strftime('Expires in ' + format));
                         })
                         .on('finish.countdown', function(event) {
                           // "Gray out" background of iFrame


### PR DESCRIPTION
@charman This fixes the bug where the countdown timer for assignments only goes up to 24 hours.

What I'm doing here is showing the time in H:M if less than 48 hours. I assume someone needs the granularity of hours if less than that time is left. I show the number of days if two days or more.

I could extend that to 72 hours so that someone on a Friday can be sure whether the assignment will still be available on the next Monday.