### PR TITLE
WIP: Fixes #94 prevents annotators from working on a preview

### DIFF
--- a/turkle/static/turkle/css/turkle.css
+++ b/turkle/static/turkle/css/turkle.css
@@ -54,11 +54,6 @@ iframe {
 }
 
 div.task-preview {
-  background: #000;
   height: 100%;
   display: block;
-}
-.task-preview iframe {
-  background: #fff;
-  opacity: 0.8;
 }

--- a/turkle/templates/preview_iframe.html
+++ b/turkle/templates/preview_iframe.html
@@ -19,5 +19,9 @@
       </p>
       {% endif %}
     </form>
+    {% if 'hitId' in request.GET %}
+    {# When viewed by annotators, indicate this is a preview only #}
+    <div style="position: fixed; top: 0; left: 0; bottom: 0; right: 0; height: 100%; z-index: 30000; background-color: black; opacity: 0.1;"></div>
+    {% endif %}
   </body>
 </html>

--- a/turkle/views.py
+++ b/turkle/views.py
@@ -314,7 +314,7 @@ def preview_iframe(request, task_id):
         messages.error(request, 'You do not have permission to view this Task')
         return redirect(index)
 
-    return render(request, 'preview_iframe.html', {'task': task})
+    return render(request, 'preview_iframe.html', {'request': request, 'task': task})
 
 
 def preview_next_task(request, batch_id):


### PR DESCRIPTION
This positions a div over the form so that a user cannot enter data into the form. It also grays out the form.

This tries to solve the problem of an annotator previewing a task, starting to work on it, and forgetting that it is just a preview and cannot be submitted. It seems like the previous gray overlay wasn't obvious enough.