### PR TITLE
Fixes #106 adds activate and deactivate actions to the user list

### DIFF
--- a/turkle/admin.py
+++ b/turkle/admin.py
@@ -25,6 +25,7 @@ from django.shortcuts import redirect, render
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
+from django.utils.translation import ngettext
 from guardian.admin import GuardedModelAdmin
 from guardian.shortcuts import assign_perm, get_groups_with_perms, remove_perm
 import humanfriendly
@@ -145,6 +146,34 @@ class CustomUserAdmin(UserAdmin):
         ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser',
                                     'groups')}),
     )
+    actions = ['activate_users', 'deactivate_users']
+    list_display = ('username', 'email', 'first_name', 'last_name', 'is_staff', 'is_active')
+
+    def activate_users(self, request, queryset):
+        updated = queryset.update(is_active=True)
+        self.message_user(request, ngettext(
+            '%d user was activated.',
+            '%d users were activated.',
+            updated,
+        ) % updated, messages.SUCCESS)
+    activate_users.short_description = "Activate selected users"
+
+    def deactivate_users(self, request, queryset):
+        # do not deactivate the logged in user nor the anonymous user object
+        queryset = queryset.exclude(username="AnonymousUser")
+        queryset = queryset.exclude(username=request.user.username)
+        updated = queryset.update(is_active=False)
+        self.message_user(request, ngettext(
+            '%d user was deactivated.',
+            '%d users were deactivated.',
+            updated,
+        ) % updated, messages.SUCCESS)
+    deactivate_users.short_description = "Deactivate selected users"
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop('delete_selected', None)
+        return actions
 
     def get_urls(self):
         urls = super().get_urls()


### PR DESCRIPTION
1. Adds a bulk deactivate action to the user list view (checks to make sure we don't deactivate the anonymous user or the current admin)
2. Adds a bulk activate action because why not
3. Removes the bulk delete action. Admins can still delete individual users on their edit pages. This is probably the only controversial change and I can be convinced to revert that part. 