### PR TITLE
Fies #75 removes about and adds admin footer with version

### DIFF
--- a/turkle/admin.py
+++ b/turkle/admin.py
@@ -29,7 +29,6 @@ from guardian.admin import GuardedModelAdmin
 from guardian.shortcuts import assign_perm, get_groups_with_perms, remove_perm
 import humanfriendly
 
-from . import __version__
 from .models import Batch, Project, TaskAssignment
 from .utils import get_site_name, get_turkle_template_limit
 
@@ -45,14 +44,6 @@ class TurkleAdminSite(admin.AdminSite):
     site_header = get_site_name() + ' administration'
     site_title = get_site_name() + ' site admin'
 
-    def about(self, request):
-        return render(request, 'admin/turkle/about.html', {
-            'title': 'About',
-            'site_title': self.site_title,
-            'site_header': self.site_header,
-            'version': __version__,
-        })
-
     def expire_abandoned_assignments(self, request):
         (total_deleted, _) = TaskAssignment.expire_all_abandoned()
         messages.info(request, 'All {} abandoned Tasks have been expired'.format(total_deleted))
@@ -61,7 +52,6 @@ class TurkleAdminSite(admin.AdminSite):
     def get_urls(self):
         urls = super().get_urls()
         my_urls = [
-            url(r'^about/$', self.admin_view(self.about), name='about'),
             url(r'^expire_abandoned_assignments/$',
                 self.admin_view(self.expire_abandoned_assignments),
                 name='expire_abandoned_assignments'),

--- a/turkle/static/admin/css/turkle-admin.css
+++ b/turkle/static/admin/css/turkle-admin.css
@@ -69,3 +69,12 @@ textarea.parsley-error {
 .parsley-errors-list.filled {
   opacity: 1;
 }
+
+#footer {
+  background: #79aec8;
+  padding: 10px 40px;
+  border: none;
+  font-size: 14px;
+  color: #fff;
+  text-align: right;
+}

--- a/turkle/templates/admin/base_site.html
+++ b/turkle/templates/admin/base_site.html
@@ -10,3 +10,5 @@
 {% block nav-global %}{% endblock %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/turkle-admin.css" %}" />{% endblock %}
+
+{% block footer %}<div id="footer">Turkle version {{turkle_version}}</div>{% endblock %}

--- a/turkle/utils.py
+++ b/turkle/utils.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+from . import __version__
+
 
 def get_site_name():
     try:
@@ -24,4 +26,5 @@ def turkle_vars(request):
     return {
         'turkle_site_name': get_site_name(),
         'turkle_template_limit': get_turkle_template_limit(),
+        'turkle_version': __version__,
     }


### PR DESCRIPTION
There wasn't a great way to add a link to the about page and the only useful thing that page had was the turkle version. I added a footer on the admin pages with that information.

![image](https://user-images.githubusercontent.com/199558/107573902-1c6f1e00-6bbc-11eb-9371-0d51b6d0a6f1.png)
