### PR TITLE
Fixes 78 setting a batch as inactive stops work

### DIFF
--- a/turkle/models.py
+++ b/turkle/models.py
@@ -318,6 +318,8 @@ class Batch(TaskAssignmentStatistics, models.Model):
         """
         if not user.is_authenticated and self.login_required:
             return False
+        elif not self.active:
+            return False
         elif self.custom_permissions:
             return user.has_perm('can_work_on_batch', self)
         else:
@@ -335,7 +337,7 @@ class Batch(TaskAssignmentStatistics, models.Model):
         Returns:
             QuerySet of Task objects
         """
-        if not user.is_authenticated and self.login_required:
+        if not self.active or not user.is_authenticated and self.login_required:
             return Task.objects.none()
 
         hs = self.task_set.filter(completed=False)

--- a/turkle/tests/test_models.py
+++ b/turkle/tests/test_models.py
@@ -250,6 +250,32 @@ class TestBatch(django.test.TestCase):
         # add superusers should have access to it
         self.assertEqual(len(batch.access_permitted_for(self.admin)), 1)
 
+    def test_available_for(self):
+        user = User.objects.create_user('testuser', password='secret')
+        project = Project.objects.create()
+        batch = Batch.objects.create(project=project)
+
+        self.assertTrue(batch.available_for(user))
+
+        batch.active = False
+        self.assertFalse(batch.available_for(user))
+
+    def test_available_tasks_for(self):
+        user = User.objects.create_user('testuser', password='secret')
+        project = Project.objects.create()
+        batch = Batch.objects.create(project=project)
+        task1 = Task(
+            batch=batch,
+            completed=False,
+            input_csv_fields={'number': '1', 'letter': 'a'},
+        )
+        task1.save()
+
+        self.assertEqual(1, len(batch.available_tasks_for(user)))
+
+        batch.active = False
+        self.assertEqual(0, len(batch.available_tasks_for(user)))
+
     def test_batch_to_csv(self):
         template = '<p>${number} - ${letter}</p><textarea>'
         project = Project.objects.create(name='test', html_template=template)


### PR DESCRIPTION
Note that this stops users from previewing tasks or accepting tasks. It does not stop someone who had already accepted the task from submitting the answer.