### PR TITLE
Fixes #94 adds a banner to indicate a preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added statistics about not-yet-completed Task Assignments to
   Project Stats page.
+- Banner for the preview page added to warn users that any work
+  won't be saved. 
 
 ### Fixed
 - Task Assignments from inactive Batches and/or Projects are no

--- a/turkle/templates/preview.html
+++ b/turkle/templates/preview.html
@@ -8,6 +8,10 @@
 
 {% block body %}
 <div class="container-fluid content">
+  <div class="alert alert-primary my-2">
+    <h2 class="alert-heading text-center">This is only a preview.</h2>
+    <div class="text-center">Any changes will not be saved. You must accept the task first before working on it.</div>
+  </div>
   <div class="task-preview">
     <iframe src="{% url 'preview_iframe' task.id %}{{ http_get_params }}"
             id="task_assignment_iframe">


### PR DESCRIPTION
Instead of putting a div at a high z-index preventing people from interacting with the task, this puts a large banner at the top reminding them that is a preview. The banner is in the page not the iframe so it is also visible. I also made the iframe a little darker by adjusting the opacity.

![image](https://user-images.githubusercontent.com/199558/113485838-9cf42180-947d-11eb-8c44-ec1df819139d.png)
