### PR TITLE
Display incomplete Task Assignments on Batch Stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Project Stats page.
 - Banner for the preview page added to warn users that any work
   won't be saved.
+- Batch Statistics page now includes table of Unsubmitted Assignments
 - Tables on Batch Stats and Project Stats pages are now sortable
   by clicking on column headings
 

--- a/turkle/admin.py
+++ b/turkle/admin.py
@@ -524,6 +524,7 @@ class BatchAdmin(admin.ModelAdmin):
             'batch_median_work_time': median_work_time,
             'first_finished_time': first_finished_time,
             'last_finished_time': last_finished_time,
+            'unfinished_task_assignments': batch.unfinished_task_assignments(),
             'stats_users': stats_users,
         })
 

--- a/turkle/admin.py
+++ b/turkle/admin.py
@@ -524,7 +524,7 @@ class BatchAdmin(admin.ModelAdmin):
             'batch_median_work_time': median_work_time,
             'first_finished_time': first_finished_time,
             'last_finished_time': last_finished_time,
-            'unfinished_task_assignments': batch.unfinished_task_assignments(),
+            'unsubmitted_task_assignments': batch.unfinished_task_assignments(),
             'stats_users': stats_users,
         })
 

--- a/turkle/models.py
+++ b/turkle/models.py
@@ -523,6 +523,15 @@ class Batch(TaskAssignmentStatistics, models.Model):
         for task in tasks:
             writer.writerow(task.input_csv_fields)
 
+    def unfinished_task_assignments(self):
+        """
+        Returns:
+            QuerySet of all Task Assignment objects associated with this Batch
+            that have not been completed.
+        """
+        return TaskAssignment.objects.filter(task__batch_id=self.id)\
+                                     .filter(completed=False)
+
     def unfinished_tasks(self):
         """
         Returns:

--- a/turkle/templates/admin/turkle/batch_stats.html
+++ b/turkle/templates/admin/turkle/batch_stats.html
@@ -5,8 +5,19 @@
 <script type="text/javascript" src="{% static 'turkle/jquery-3.3.1.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'turkle/datatables-1.10.24/datatables.min.js' %}"></script>
 <link href="{% static 'turkle/datatables-1.10.24/datatables.bootstrap4.min.css' %}" rel="stylesheet" type="text/css"/>
+<style>
+#incomplete-assignment-stats-div {
+  margin-bottom: 1em;
+}
+</style>
 <script>
 $(document).ready(function() {
+  $('#incomplete-assignment-stats').DataTable({
+    info: false,
+    paging: false,
+    searching: false
+  });
+
   $('#user-stats').DataTable({
     info: false,
     paging: false,
@@ -97,6 +108,43 @@ $(document).ready(function() {
         <td></td>
       </tr>
       -->
+    </table>
+  </div>
+
+  <h2>Assigned but not Completed Task Assignments</h2>
+
+  <div id="incomplete-assignment-stats-div">
+    <table id="incomplete-assignment-stats" class="table table-sm table-bordered">
+      <thead class="thead-light">
+	<tr>
+	  <th>Assignment ID</th>
+          <th>Username</th>
+          <th>Name</th>
+	  <th>Created at</th>
+	  <th>Expires at</th>
+	</tr>
+      </thead>
+      <tbody>
+	{% for uta in unfinished_task_assignments %}
+	<tr>
+	  <td>
+	    {{ uta.id }}
+	  </td>
+	  <td>
+	    {{ uta.assigned_to.username }}
+	  </td>
+	  <td>
+	    {{ uta.assigned_to.get_full_name }}
+	  </td>
+	  <td data-order="{{ uta.created_at|date:'c' }}">
+	    {{ uta.created_at }}
+	  </td>
+	  <td data-order="{{ uta.expires_at|date:'c' }}">
+	    {{ uta.expires_at }}
+	  </td>
+	</tr>
+	{% endfor %}
+      </tbody>
     </table>
   </div>
 

--- a/turkle/templates/admin/turkle/batch_stats.html
+++ b/turkle/templates/admin/turkle/batch_stats.html
@@ -6,13 +6,13 @@
 <script type="text/javascript" src="{% static 'turkle/datatables-1.10.24/datatables.min.js' %}"></script>
 <link href="{% static 'turkle/datatables-1.10.24/datatables.bootstrap4.min.css' %}" rel="stylesheet" type="text/css"/>
 <style>
-#incomplete-assignment-stats-div {
+#user-statistics-div {
   margin-bottom: 1em;
 }
 </style>
 <script>
 $(document).ready(function() {
-  $('#incomplete-assignment-stats').DataTable({
+  $('#unsubmitted-assignment-stats').DataTable({
     info: false,
     paging: false,
     searching: false
@@ -111,46 +111,9 @@ $(document).ready(function() {
     </table>
   </div>
 
-  <h2>Assigned but not Completed Task Assignments</h2>
-
-  <div id="incomplete-assignment-stats-div">
-    <table id="incomplete-assignment-stats" class="table table-sm table-bordered">
-      <thead class="thead-light">
-	<tr>
-	  <th>Assignment ID</th>
-          <th>Username</th>
-          <th>Name</th>
-	  <th>Created at</th>
-	  <th>Expires at</th>
-	</tr>
-      </thead>
-      <tbody>
-	{% for uta in unfinished_task_assignments %}
-	<tr>
-	  <td>
-	    {{ uta.id }}
-	  </td>
-	  <td>
-	    {{ uta.assigned_to.username }}
-	  </td>
-	  <td>
-	    {{ uta.assigned_to.get_full_name }}
-	  </td>
-	  <td data-order="{{ uta.created_at|date:'c' }}">
-	    {{ uta.created_at }}
-	  </td>
-	  <td data-order="{{ uta.expires_at|date:'c' }}">
-	    {{ uta.expires_at }}
-	  </td>
-	</tr>
-	{% endfor %}
-      </tbody>
-    </table>
-  </div>
-
   <h2>User Statistics</h2>
 
-  <div>
+  <div id="user-statistics-div">
     <table id="user-stats" class="table table-sm table-bordered">
       <thead class="thead-light">
         <tr>
@@ -185,6 +148,43 @@ $(document).ready(function() {
 	  {% endif %}
         </tr>
         {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Unsubmitted Assignments</h2>
+
+  <div>
+    <table id="unsubmitted-assignment-stats" class="table table-sm table-bordered">
+      <thead class="thead-light">
+	<tr>
+	  <th>Assignment ID</th>
+          <th>Username</th>
+          <th>Name</th>
+	  <th>Created at</th>
+	  <th>Expires at</th>
+	</tr>
+      </thead>
+      <tbody>
+	{% for uta in unsubmitted_task_assignments %}
+	<tr>
+	  <td>
+	    {{ uta.id }}
+	  </td>
+	  <td>
+	    {{ uta.assigned_to.username }}
+	  </td>
+	  <td>
+	    {{ uta.assigned_to.get_full_name }}
+	  </td>
+	  <td data-order="{{ uta.created_at|date:'c' }}">
+	    {{ uta.created_at }}
+	  </td>
+	  <td data-order="{{ uta.expires_at|date:'c' }}">
+	    {{ uta.expires_at }}
+	  </td>
+	</tr>
+	{% endfor %}
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
Closes #114.

Adds a sortable table of incomplete Task Assignments to the Batch Stats page:

<img width="1197" alt="Screen Shot 2021-04-06 at 6 28 48 PM" src="https://user-images.githubusercontent.com/424563/113786331-e905c700-9706-11eb-8e58-4f4f236d09aa.png">
