### PR TITLE
Closes #160 Upgrades to Django 3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
-Django~=2.2.13
-django-admin-autocomplete-filter==0.5
-django-guardian==2.3.0
+Django~=3.1.14
+django-admin-autocomplete-filter==0.7.1
+django-guardian==2.4.0
 humanfriendly
-jsonfield==2.0.2
+jsonfield==3.1.0
 requests

--- a/turkle_site/settings.py
+++ b/turkle_site/settings.py
@@ -7,6 +7,7 @@ import types
 
 DEBUG = False
 ALLOWED_HOSTS = ['*']
+X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 TURKLE_SITE_NAME = 'Turkle'
 
@@ -64,6 +65,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
+                'django.template.context_processors.request',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',

--- a/turkle_site/settings.py
+++ b/turkle_site/settings.py
@@ -127,10 +127,6 @@ LOGIN_REDIRECT_URL = 'index'
 # This requires MTA configuration.
 TURKLE_EMAIL_ENABLED = False
 
-# Uncomment and configure (Note: this does not work for sqlite databases)
-# DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
-# DBBACKUP_STORAGE_OPTIONS = {'location': '/opt/backups'}
-
 
 # Docker specific configuration
 


### PR DESCRIPTION
- Upgrades Django and our dependencies
- Add a context processor that turns on admin sidebar for better navigation (was causing a warning without change)
- Set explicit iframe source permissions due to change in Django 3
- Removes old dbbackup settings that were missed previously

The autocomplete filter app is not compatible with Django 3.2 yet.

I chose not to switch from the jsonfield app to the new builtin JSONField because we don't need any of the query capabilities that Django's implementation provides (query on subfields). The Django version uses a unique database field type to support that while the jsonfield app uses a normal text field. Depending on how the database engines implement JSON subfield querying, it could add significant storage space to index those fields.
