### PR TITLE
Closes #100 turn turkle into an installable package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ logs/
 !hits/tests/resources/*.csv
 !hits/tests/resources/*.html
 .DS_Store
+*.egg-info/
+build/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include turkle/static *
+recursive-include turkle/templates *

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+import setuptools
+
+with open("turkle/__init__.py") as fp:
+    ns = {}
+    exec(fp.read(), ns)
+
+with open("README.rst") as fp:
+    long_description = fp.read()
+
+with open('requirements.txt') as f:
+    requirements = [line.strip() for line in f]
+
+setuptools.setup(
+    name="turkle",
+    version=ns["__version__"],
+    description="Django-based clone of Amazon's Mechanical Turk service",
+    long_description=long_description,
+    url="https://github.com/hltcoe/turkle",
+    project_urls={
+        "Documentation": "https://turkle.readthedocs.io/",
+    },
+    author="Craig Harman",
+    author_email="craig@craigharman.net",
+    license="BSD",
+    packages=setuptools.find_packages(exclude=['scripts', 'turkle_site', 'turkle.tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    python_requires=">=3.6",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+    ],
+    keywords=['annotation', 'crowdsourcing', 'mturk', 'mechanical turk'],
+)


### PR DESCRIPTION
Based this on @TomLippincott earlier branch. This makes the package installable and gets all the necessary files in the package. I excluded tests because they require the client scripts which we will probably remove in the future.