### PR TITLE
dynamically updates login page if django-monitor-consent is installed

### DIFF
--- a/turkle/templates/registration/login.html
+++ b/turkle/templates/registration/login.html
@@ -4,10 +4,12 @@
 
 {% block body %}
 
+<div class="container-fluid mt-3">
+
 {% load turkle_tags %}
 {% is_installed "consent" as consent_installed %}
 {% if consent_installed %}
-{% load consent_tags %}{% consent_banner %}
+{% include "consent/banner.html" %}
 {% endif %}
 
 {% if form.non_field_errors %}
@@ -63,5 +65,6 @@
   </div>
   <input type="hidden" name="next" value="{{ next }}">
 </form>
+</div>
 
 {% endblock %}

--- a/turkle/templates/registration/login.html
+++ b/turkle/templates/registration/login.html
@@ -4,6 +4,12 @@
 
 {% block body %}
 
+{% load turkle_tags %}
+{% is_installed "consent" as consent_installed %}
+{% if consent_installed %}
+{% load consent_tags %}{% consent_banner %}
+{% endif %}
+
 {% if form.non_field_errors %}
 {% for error in form.non_field_errors %}
 <div class="alert alert-error" role="alert">

--- a/turkle/templatetags/turkle_tags.py
+++ b/turkle/templatetags/turkle_tags.py
@@ -1,7 +1,13 @@
 from django import template
+from django.conf import settings
 from django.utils.safestring import mark_safe
 
 register = template.Library()
+
+
+@register.simple_tag
+def is_installed(app):
+    return app in settings.INSTALLED_APPS
 
 
 @register.filter


### PR DESCRIPTION
Adds a new template tag that checks if app is installed and then uses that in the login page. To use:
  1. pip install django-monitor-consent
  2. Add "consent" to installed apps in settings
  3. Add `CONSENT_TEXT="my text here"` in settings

A banner will appear on the login page with the configured text. https://pypi.org/project/django-monitor-consent/