### PR TITLE
adds setting for configuring whether anonymous tasks are allowed

### DIFF
--- a/turkle/admin.py
+++ b/turkle/admin.py
@@ -31,7 +31,7 @@ from guardian.shortcuts import (assign_perm, get_groups_with_perms, get_users_wi
 import humanfriendly
 
 from .models import Batch, Project, TaskAssignment
-from .utils import get_site_name, get_turkle_template_limit
+from .utils import are_anonymous_tasks_allowed, get_site_name, get_turkle_template_limit
 
 logger = logging.getLogger(__name__)
 
@@ -295,6 +295,10 @@ class BatchForm(ModelForm):
 
         self.fields['active'].help_text = 'Workers can only access a Batch if both the Batch ' + \
             'itself and the associated Project are Active.'
+
+        if not are_anonymous_tasks_allowed():
+            # default value of login_required is True
+            self.fields['login_required'].widget = HiddenInput()
 
         if self.instance._state.adding and 'project' in self.initial:
             # We are adding a new Batch where the associated Project has been specified.
@@ -875,6 +879,10 @@ class ProjectForm(ModelForm):
         # customized admin template file:
         #   turkle/templates/admin/turkle/project/change_form.html
         self.fields['filename'].widget = HiddenInput()
+
+        if not are_anonymous_tasks_allowed():
+            # default value of login_required is True
+            self.fields['login_required'].widget = HiddenInput()
 
         self.fields['allotted_assignment_time'].label = 'Allotted Assignment Time (hours)'
         self.fields['allotted_assignment_time'].help_text = 'If a user abandons a Task, ' + \

--- a/turkle/utils.py
+++ b/turkle/utils.py
@@ -32,3 +32,7 @@ def turkle_vars(request):
         'turkle_email_enabled': settings.TURKLE_EMAIL_ENABLED,
         'turkle_meta_tags': meta_tags,
     }
+
+
+def are_anonymous_tasks_allowed():
+    return getattr(settings, 'TURKLE_ANONYMOUS_TASKS', True)


### PR DESCRIPTION
Adds ability for a site administrator to turn off anonymous projects/batches. Does not retroactively change settings on previously created projects/batches. Expected to be set when site is created.

To turn off anonymous access:
```
TURKLE_ANONYMOUS_TASKS = False
```
