### PR TITLE
cleared up documentation on hitting gunicorn-served app in sub-directory

### DIFF
--- a/docs/DOCKER.rst
+++ b/docs/DOCKER.rst
@@ -110,5 +110,6 @@ Then run the docker container::
     docker run -d --name [container_name] -p 8080:8080 -e TURKLE_PREFIX='annotate' hltcoe/turkle
 
 This passes the URL prefix to the Turkle application through an environment variable.
-Note that the application will be functional when directly hitting the application server.
-If that is required, use ``SCRIPT_NAME`` with your own Docker image.
+
+Note that after you specify the prefix as an environment variable, you will not be able to
+hit the Docker-served application directly from a web browser, but only through the reverse proxy.


### PR DESCRIPTION
Gunicorn is getting data from the reverse proxy and mapping URLs like /prefix/admin to /admin. But if you hit it directly, that doesn't work. It is missing the SCRIPT_NAME HTTP header. An example with python requests library:

```
resp = requests.get("http://localhost:18080/prefix/help/", headers={'SCRIPT_NAME':'/prefix'})
```

The previous documentation on this was confusing and I think we should leave it up to the developer who needs the prefix support to figure out how they want to interact with the Docker container running gunicorn.