### PR TITLE
Add encoding parameter to read_file function

### DIFF
--- a/scripts/client.py
+++ b/scripts/client.py
@@ -196,7 +196,7 @@ class TurkleClient(object):
 
     @staticmethod
     def read_file(filename):
-        with open(filename, "r") as fh:
+        with open(filename, "r", encoding='latin-1') as fh:
             data = fh.read()
             return data
 


### PR DESCRIPTION
I had problems with uploading the CSV files in different languages. This change sets the encoding to `latin-1`. This can help prevent issues with reading files that contain characters, not in the default encoding.