### PR TITLE
enable admins to delete users with assignments

### DIFF
--- a/turkle/admin.py
+++ b/turkle/admin.py
@@ -1198,13 +1198,17 @@ class ViewOnlyAdminMixin:
         return False
 
 
-class TaskAssignmentAdmin(ViewOnlyAdminMixin, admin.ModelAdmin):
+class TaskAssignmentAdmin(admin.ModelAdmin):
     """View for assignments to expire abandoned ones"""
 
     class Media:
         css = {
             'all': ('turkle/css/admin-turkle.css',),
         }
+
+    # this turns off the add button in admin sidebar for task assignments
+    def has_add_permission(self, request):
+        return False
 
     def changelist_view(self, request, extra_context=None):
         num_incomplete_tasks = TaskAssignment.objects.\


### PR DESCRIPTION
The view only mixin was preventing any assignments from being deleted so removed that and added has_add_permission() to TaskAssignmentAdmin so that the add option is removed from the admin sidebar