### PR TITLE
modify csv download filename

### DIFF
--- a/turkle/models.py
+++ b/turkle/models.py
@@ -436,7 +436,7 @@ class Batch(TaskAssignmentStatistics, models.Model):
         batch_filename, extension = os.path.splitext(os.path.basename(self.filename))
 
         # We are deviating from Mechanical Turk's naming conventions for results files
-        return "Project-{}_Batch-{}-{}_results{}".format(\
+        return "Project-{}_Batch-{}-{}_results{}".format(
             Project.objects.get(name=self.project).id, self.id, batch_filename, extension)
 
     def create_tasks_from_csv(self, csv_fh):

--- a/turkle/models.py
+++ b/turkle/models.py
@@ -435,8 +435,8 @@ class Batch(TaskAssignmentStatistics, models.Model):
         """
         batch_filename, extension = os.path.splitext(os.path.basename(self.filename))
 
-        # We are following Mechanical Turk's naming conventions for results files
-        return "{}-Batch_{}_results{}".format(batch_filename, self.id, extension)
+        # We are deviating from Mechanical Turk's naming conventions for results files
+        return "Project-{}_Batch-{}-{}_results{}".format(Project.objects.get(name=self.project).id, self.id, batch_filename, extension)
 
     def create_tasks_from_csv(self, csv_fh):
         """

--- a/turkle/models.py
+++ b/turkle/models.py
@@ -436,7 +436,8 @@ class Batch(TaskAssignmentStatistics, models.Model):
         batch_filename, extension = os.path.splitext(os.path.basename(self.filename))
 
         # We are deviating from Mechanical Turk's naming conventions for results files
-        return "Project-{}_Batch-{}-{}_results{}".format(Project.objects.get(name=self.project).id, self.id, batch_filename, extension)
+        return "Project-{}_Batch-{}-{}_results{}".format(\
+            Project.objects.get(name=self.project).id, self.id, batch_filename, extension)
 
     def create_tasks_from_csv(self, csv_fh):
         """


### PR DESCRIPTION
Rename of batch files downloaded through the `CSV Results` button. Leading project id values in the name should allow for related batches to be easily identified. Verbose project name is redundant to project id but maintained for human readability.
![image](https://github.com/hltcoe/turkle/assets/46499982/7d57f7f5-0090-4221-b039-4026f2111746)

