### PR TITLE
Closes #192 Upgrade Django version to 4.0.*

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -46,7 +46,7 @@ in the docs directory.
 Installation
 ============
 
-Turkle works with Python 3.6+.
+Turkle works with Python 3.8+.
 
 This Installation section covers the quickest and easiest way to use
 Turkle with a few users on your local network by using the

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4
 Django~=4.0.10
 django-admin-autocomplete-list-filter2==1.0.3
 django-guardian==2.4.0
-djangorestframework==3.13.1
+djangorestframework==3.14.0
 drf-nested-routers==0.93.4
 humanfriendly
 jsonfield==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
-Django~=3.2.16
-django-admin-autocomplete-list-filter==1.0.1
+Django~=4.0.10
+django-admin-autocomplete-list-filters2==1.0.2
 django-guardian==2.4.0
 djangorestframework==3.13.1
 drf-nested-routers==0.93.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
 Django~=4.0.10
-django-admin-autocomplete-list-filters2==1.0.2
+django-admin-autocomplete-list-filter2==1.0.3
 django-guardian==2.4.0
 djangorestframework==3.13.1
 drf-nested-routers==0.93.4

--- a/turkle/admin.py
+++ b/turkle/admin.py
@@ -7,7 +7,7 @@ import json
 import logging
 import statistics
 
-from djaa_list_filter.admin import AjaxAutocompleteListFilterModelAdmin
+from djaa_list_filter2.admin import AjaxAutocompleteListFilterModelAdmin
 
 from django.contrib import admin, messages
 from django.contrib.admin.templatetags.admin_list import _boolean_icon

--- a/turkle_site/settings.py
+++ b/turkle_site/settings.py
@@ -112,7 +112,7 @@ INSTALLED_APPS = (
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
     'guardian',
-    'djaa_list_filter',
+    'djaa_list_filter2',
 )
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
Had to do my own fork on the admin autocomplete filter since the 4.0 compatible version was never released